### PR TITLE
Change getFields type & move TopMetrics to a separate component

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/aggregations.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/aggregations.ts
@@ -66,3 +66,14 @@ export type BucketAggregation = DateHistogram | Histogram | Terms | Filters | Ge
 export const isBucketAggregationWithField = (
   bucketAgg: BucketAggregation | BucketAggregationWithField
 ): bucketAgg is BucketAggregationWithField => bucketAggregationConfig[bucketAgg.type].requiresField;
+
+export const BUCKET_AGGREGATION_TYPES: BucketAggregationType[] = [
+  'date_histogram',
+  'histogram',
+  'terms',
+  'filters',
+  'geohash_grid',
+];
+
+export const isBucketAggregationType = (s: BucketAggregationType | string): s is BucketAggregationType =>
+  BUCKET_AGGREGATION_TYPES.includes(s as BucketAggregationType);

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/TopMetricsSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/TopMetricsSettingsEditor.tsx
@@ -7,6 +7,7 @@ import { SettingField } from './SettingField';
 import { orderOptions } from '../../BucketAggregationsEditor/utils';
 import { range } from 'lodash';
 import { useFields } from 'app/plugins/datasource/elasticsearch/hooks/useFields';
+import { css } from '@emotion/css';
 
 const aggregateByOptions = [
   { value: 'avg', label: 'Average' },
@@ -33,8 +34,19 @@ export const TopMetricsSettingsEditor: FunctionComponent<Props> = ({ metric }) =
           value={metric.settings?.order}
         />
       </InlineField>
-      <InlineField label="Order by" labelWidth={16}>
+      <InlineField
+        label="Order By"
+        labelWidth={16}
+        className={css`
+          & > div {
+            width: 100%;
+          }
+        `}
+      >
         <SegmentAsync
+          className={css`
+            margin-right: 0;
+          `}
           loadOptions={getFields}
           onChange={(e) => dispatch(changeMetricSetting(metric, 'orderBy', e.value))}
           placeholder="Select Field"

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/TopMetricsSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/TopMetricsSettingsEditor.tsx
@@ -1,0 +1,63 @@
+import { InlineField, SegmentAsync, Select } from '@grafana/ui';
+import React, { FunctionComponent } from 'react';
+import { useDispatch } from '../../../../hooks/useStatelessReducer';
+import { TopMetrics } from '../aggregations';
+import { changeMetricSetting } from '../state/actions';
+import { SettingField } from './SettingField';
+import { orderOptions } from '../../BucketAggregationsEditor/utils';
+import { range } from 'lodash';
+import { useFields } from 'app/plugins/datasource/elasticsearch/hooks/useFields';
+
+const aggregateByOptions = [
+  { value: 'avg', label: 'Average' },
+  { value: 'sum', label: 'Sum' },
+  { value: 'max', label: 'Max' },
+  { value: 'min', label: 'Min' },
+  { value: 'concat', label: 'Concatenate' },
+];
+
+interface Props {
+  metric: TopMetrics;
+}
+
+export const TopMetricsSettingsEditor: FunctionComponent<Props> = ({ metric }) => {
+  const dispatch = useDispatch();
+  const getFields = useFields(['number', 'date', 'boolean']);
+
+  return (
+    <>
+      <InlineField label="Order" labelWidth={16}>
+        <Select
+          onChange={(e) => dispatch(changeMetricSetting(metric, 'order', e.value))}
+          options={orderOptions}
+          value={metric.settings?.order}
+        />
+      </InlineField>
+      <InlineField label="Order by" labelWidth={16}>
+        <SegmentAsync
+          loadOptions={getFields}
+          onChange={(e) => dispatch(changeMetricSetting(metric, 'orderBy', e.value))}
+          placeholder="Select Field"
+          value={metric.settings?.orderBy}
+        />
+      </InlineField>
+      <InlineField label="Size" labelWidth={16}>
+        <Select
+          onChange={(e) => dispatch(changeMetricSetting(metric, 'size', e.value))}
+          options={range(0, 10).map((value) => ({ value: value + 1, label: `${value + 1}` }))}
+          value={metric.settings?.size ?? 1}
+        />
+      </InlineField>
+      <InlineField label="Aggregate by" labelWidth={16}>
+        <Select
+          onChange={(e) => dispatch(changeMetricSetting(metric, 'aggregateBy', e.value))}
+          options={aggregateByOptions}
+          value={metric.settings?.aggregateBy}
+        />
+      </InlineField>
+      {metric.settings?.aggregateBy === 'concat' && (
+        <SettingField label="Separator" metric={metric} settingName="separator" />
+      )}
+    </>
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/TopMetricsSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/TopMetricsSettingsEditor.tsx
@@ -1,4 +1,4 @@
-import { InlineField, SegmentAsync, Select } from '@grafana/ui';
+import { AsyncMultiSelect, InlineField, SegmentAsync, Select } from '@grafana/ui';
 import React, { FunctionComponent } from 'react';
 import { useDispatch } from '../../../../hooks/useStatelessReducer';
 import { TopMetrics } from '../aggregations';
@@ -8,6 +8,7 @@ import { orderOptions } from '../../BucketAggregationsEditor/utils';
 import { range } from 'lodash';
 import { useFields } from 'app/plugins/datasource/elasticsearch/hooks/useFields';
 import { css } from '@emotion/css';
+import { SelectableValue } from '@grafana/data';
 
 const aggregateByOptions = [
   { value: 'avg', label: 'Average' },
@@ -21,12 +22,32 @@ interface Props {
   metric: TopMetrics;
 }
 
+const toMultiSelectValue = (value: string): SelectableValue<string> => ({ value, label: value });
+
 export const TopMetricsSettingsEditor: FunctionComponent<Props> = ({ metric }) => {
   const dispatch = useDispatch();
-  const getFields = useFields(['number', 'date', 'boolean']);
+  const getOrderByOptions = useFields(['number', 'date', 'boolean']);
+  const getMetricsOptions = useFields(metric.type);
 
   return (
     <>
+      <InlineField label="Metrics" labelWidth={16}>
+        <AsyncMultiSelect
+          onChange={(e) =>
+            dispatch(
+              changeMetricSetting(
+                metric,
+                'metrics',
+                e.map((v) => v.value!)
+              )
+            )
+          }
+          loadOptions={getMetricsOptions}
+          value={metric.settings?.metrics?.map(toMultiSelectValue)}
+          closeMenuOnSelect={false}
+          defaultOptions
+        />
+      </InlineField>
       <InlineField label="Order" labelWidth={16}>
         <Select
           onChange={(e) => dispatch(changeMetricSetting(metric, 'order', e.value))}
@@ -47,7 +68,7 @@ export const TopMetricsSettingsEditor: FunctionComponent<Props> = ({ metric }) =
           className={css`
             margin-right: 0;
           `}
-          loadOptions={getFields}
+          loadOptions={getOrderByOptions}
           onChange={(e) => dispatch(changeMetricSetting(metric, 'orderBy', e.value))}
           placeholder="Select Field"
           value={metric.settings?.orderBy}
@@ -56,8 +77,8 @@ export const TopMetricsSettingsEditor: FunctionComponent<Props> = ({ metric }) =
       <InlineField label="Size" labelWidth={16}>
         <Select
           onChange={(e) => dispatch(changeMetricSetting(metric, 'size', e.value))}
-          options={range(0, 10).map((value) => ({ value: value + 1, label: `${value + 1}` }))}
-          value={metric.settings?.size ?? 1}
+          options={range(0, 10).map((value) => ({ value: `${value + 1}`, label: `${value + 1}` }))}
+          value={metric.settings?.size}
         />
       </InlineField>
       <InlineField label="Aggregate by" labelWidth={16}>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -357,7 +357,7 @@ export const isMetricAggregationWithInlineScript = (
   metric: BaseMetricAggregation | MetricAggregationWithInlineScript
 ): metric is MetricAggregationWithInlineScript => metricAggregationConfig[metric.type].supportsInlineScript;
 
-export const METRIC_AGGREGATION_TYPES = [
+export const METRIC_AGGREGATION_TYPES: MetricAggregationType[] = [
   'count',
   'avg',
   'sum',
@@ -379,4 +379,4 @@ export const METRIC_AGGREGATION_TYPES = [
 ];
 
 export const isMetricAggregationType = (s: MetricAggregationType | string): s is MetricAggregationType =>
-  METRIC_AGGREGATION_TYPES.includes(s);
+  METRIC_AGGREGATION_TYPES.includes(s as MetricAggregationType);

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -283,14 +283,15 @@ export interface BucketScript extends PipelineMetricAggregationWithMultipleBucke
   };
 }
 
-export interface TopMetrics extends MetricAggregationWithField {
+export interface TopMetrics extends BaseMetricAggregation {
   type: 'top_metrics';
   settings?: {
     order?: string;
     orderBy?: string;
-    size?: number;
+    size?: string;
     aggregateBy?: string;
     separator?: string;
+    metrics?: string[];
   };
 }
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
@@ -244,7 +244,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
     label: 'Top Metrics',
     xpack: true,
     minVersion: 77,
-    requiresField: true,
+    requiresField: false,
     isPipelineAgg: false,
     supportsMissing: false,
     supportsMultipleBucketPaths: false,
@@ -253,11 +253,9 @@ export const metricAggregationConfig: MetricsConfiguration = {
     hasMeta: false,
     defaults: {
       settings: {
-        size: 1,
+        size: '1',
         order: 'desc',
         aggregateBy: 'avg',
-        orderBy: '@timestamp',
-        separator: ' ',
       },
     },
   },

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/SettingsEditorContainer.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/SettingsEditorContainer.tsx
@@ -7,6 +7,7 @@ import { segmentStyles } from './styles';
 const getStyles = stylesFactory((theme: GrafanaTheme, hidden: boolean) => {
   return {
     wrapper: css`
+      max-width: 500px;
       display: flex;
       flex-direction: column;
     `,

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -478,7 +478,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should return number fields', async () => {
       const { ds } = getTestContext({ data, jsonData: { esVersion: 50 }, database: 'metricbeat' });
 
-      await expect(ds.getFields('number')).toEmitValuesWith((received) => {
+      await expect(ds.getFields(['number'])).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
         const fieldObjects = received[0];
         const fields = map(fieldObjects, 'text');
@@ -490,7 +490,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should return date fields', async () => {
       const { ds } = getTestContext({ data, jsonData: { esVersion: 50 }, database: 'metricbeat' });
 
-      await expect(ds.getFields('date')).toEmitValuesWith((received) => {
+      await expect(ds.getFields(['date'])).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
         const fieldObjects = received[0];
         const fields = map(fieldObjects, 'text');
@@ -686,6 +686,16 @@ describe('ElasticDatasource', function (this: any) {
       },
     };
 
+    const dateFields = ['@timestamp_millis'];
+    const numberFields = [
+      'justification_blob.overall_vote_score',
+      'justification_blob.shallow.jsi.sdb.dsel2.bootlegged-gille.botness',
+      'justification_blob.shallow.jsi.sdb.dsel2.bootlegged-gille.general_algorithm_score',
+      'justification_blob.shallow.jsi.sdb.dsel2.uncombed-boris.botness',
+      'justification_blob.shallow.jsi.sdb.dsel2.uncombed-boris.general_algorithm_score',
+      'overall_vote_score',
+    ];
+
     it('should return nested fields', async () => {
       const { ds } = getTestContext({ data, database: 'genuine.es7._mapping.response', jsonData: { esVersion: 70 } });
 
@@ -716,31 +726,36 @@ describe('ElasticDatasource', function (this: any) {
     it('should return number fields', async () => {
       const { ds } = getTestContext({ data, database: 'genuine.es7._mapping.response', jsonData: { esVersion: 70 } });
 
-      await expect(ds.getFields('number')).toEmitValuesWith((received) => {
+      await expect(ds.getFields(['number'])).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
 
         const fieldObjects = received[0];
         const fields = map(fieldObjects, 'text');
-        expect(fields).toEqual([
-          'justification_blob.overall_vote_score',
-          'justification_blob.shallow.jsi.sdb.dsel2.bootlegged-gille.botness',
-          'justification_blob.shallow.jsi.sdb.dsel2.bootlegged-gille.general_algorithm_score',
-          'justification_blob.shallow.jsi.sdb.dsel2.uncombed-boris.botness',
-          'justification_blob.shallow.jsi.sdb.dsel2.uncombed-boris.general_algorithm_score',
-          'overall_vote_score',
-        ]);
+        expect(fields).toEqual(numberFields);
       });
     });
 
     it('should return date fields', async () => {
       const { ds } = getTestContext({ data, database: 'genuine.es7._mapping.response', jsonData: { esVersion: 70 } });
 
-      await expect(ds.getFields('date')).toEmitValuesWith((received) => {
+      await expect(ds.getFields(['date'])).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
 
         const fieldObjects = received[0];
         const fields = map(fieldObjects, 'text');
-        expect(fields).toEqual(['@timestamp_millis']);
+        expect(fields).toEqual(dateFields);
+      });
+    });
+
+    it('should return date and number fields', async () => {
+      const { ds } = getTestContext({ data, database: 'genuine.es7._mapping.response', jsonData: { esVersion: 70 } });
+
+      await expect(ds.getFields(['date', 'number'])).toEmitValuesWith((received) => {
+        expect(received.length).toBe(1);
+
+        const fieldObjects = received[0];
+        const fields = map(fieldObjects, 'text');
+        expect(fields).toEqual([...dateFields, ...numberFields]);
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -135,33 +135,30 @@ export class ElasticResponse {
           break;
         }
         case 'top_metrics': {
-          newSeries = {
-            datapoints: [],
-            metric: metric.type,
-            metricId: metric.id,
-            props: props,
-            refId: target.refId,
-            field: metric.field,
-          };
-
-          for (let i = 0; i < esAgg.buckets.length; i++) {
-            const bucket = esAgg.buckets[i];
-            const stats = bucket[metric.id];
-            const values = stats.top.map((hit: { metrics: Record<string, number> }) => {
-              if (hit.metrics[metric.field!]) {
-                return hit.metrics[metric.field!];
-              }
-              return null;
-            });
-            newSeries.datapoints.push([
-              aggValues(metric.settings?.aggregateBy ?? 'avg', values, metric.settings?.separator),
-              bucket.key,
-            ]);
-          }
-
-          seriesList.push(newSeries);
-
-          break;
+          // newSeries = {
+          //   datapoints: [],
+          //   metric: metric.type,
+          //   metricId: metric.id,
+          //   props: props,
+          //   refId: target.refId,
+          //   field: metric.field,
+          // };
+          // for (let i = 0; i < esAgg.buckets.length; i++) {
+          //   const bucket = esAgg.buckets[i];
+          //   const stats = bucket[metric.id];
+          //   const values = stats.top.map((hit: { metrics: Record<string, number> }) => {
+          //     if (hit.metrics[metric.field!]) {
+          //       return hit.metrics[metric.field!];
+          //     }
+          //     return null;
+          //   });
+          //   newSeries.datapoints.push([
+          //     aggValues(metric.settings?.aggregateBy ?? 'avg', values, metric.settings?.separator),
+          //     bucket.key,
+          //   ]);
+          // }
+          // seriesList.push(newSeries);
+          // break;
         }
         default: {
           newSeries = {
@@ -248,19 +245,19 @@ export class ElasticResponse {
             break;
           }
           case 'top_metrics': {
-            const stats = bucket[metric.id];
-            const topMetricValues = stats.top.map((hit: { metrics: Record<string, number> }) => {
-              if (hit.metrics[metric.field!]) {
-                return hit.metrics[metric.field!];
-              }
-              return null;
-            });
-            const finalValue = aggValues(
-              metric.settings?.aggregateBy ?? 'avg',
-              topMetricValues,
-              metric.settings?.separator
-            );
-            addMetricValue(values, this.getMetricName(metric.type), finalValue);
+            // const stats = bucket[metric.id];
+            // const topMetricValues = stats.top.map((hit: { metrics: Record<string, number> }) => {
+            //   if (hit.metrics[metric.field!]) {
+            //     return hit.metrics[metric.field!];
+            //   }
+            //   return null;
+            // });
+            // const finalValue = aggValues(
+            //   metric.settings?.aggregateBy ?? 'avg',
+            //   topMetricValues,
+            //   metric.settings?.separator
+            // );
+            // addMetricValue(values, this.getMetricName(metric.type), finalValue);
             break;
           }
           case 'percentiles': {

--- a/public/app/plugins/datasource/elasticsearch/hooks/useFields.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useFields.test.tsx
@@ -50,7 +50,7 @@ describe('useFields hook', () => {
     // All other metric aggregations only work on numbers
     rerender('avg');
     result.current();
-    expect(getFields).toHaveBeenLastCalledWith('number', timeRange);
+    expect(getFields).toHaveBeenLastCalledWith(['number'], timeRange);
 
     //
     // BUCKET AGGREGATIONS
@@ -58,12 +58,12 @@ describe('useFields hook', () => {
     // Date Histrogram only works on dates
     rerender('date_histogram');
     result.current();
-    expect(getFields).toHaveBeenLastCalledWith('date', timeRange);
+    expect(getFields).toHaveBeenLastCalledWith(['date'], timeRange);
 
     // Geohash Grid only works on geo_point data
     rerender('geohash_grid');
     result.current();
-    expect(getFields).toHaveBeenLastCalledWith('geo_point', timeRange);
+    expect(getFields).toHaveBeenLastCalledWith(['geo_point'], timeRange);
 
     // All other bucket aggregation work on any kind of data
     rerender('terms');

--- a/public/app/plugins/datasource/elasticsearch/hooks/useFields.ts
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useFields.ts
@@ -12,7 +12,6 @@ import {
 type AggregationType = BucketAggregationType | MetricAggregationType;
 
 const getFilter = (type: AggregationType | string[]) => {
-  // For all metric types we want only numbers, except for cardinality
   // TODO: To have a more configuration-driven editor, it would be nice to move this logic in
   // metricAggregationConfig and bucketAggregationConfig so that each aggregation type can specify on
   // which kind of data it operates.
@@ -21,11 +20,14 @@ const getFilter = (type: AggregationType | string[]) => {
   }
 
   if (isMetricAggregationType(type)) {
-    if (!['cardinality', 'top_metrics'].includes(type)) {
-      return ['number'];
+    switch (type) {
+      case 'cardinality':
+        return void 0;
+      case 'top_metrics':
+        return ['number', 'ip'];
+      default:
+        return ['number'];
     }
-
-    return void 0;
   }
 
   if (isBucketAggregationType(type)) {

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -297,7 +297,7 @@ export class ElasticQueryBuilder {
       }
 
       const aggField: any = {};
-      let metricAgg: any = null;
+      let metricAgg: any = {};
 
       if (isPipelineAggregation(metric)) {
         if (isPipelineAggregationWithMultipleBucketPaths(metric)) {
@@ -341,13 +341,7 @@ export class ElasticQueryBuilder {
         metricAgg = { field: metric.field };
       }
 
-      if (isMetricAggregationWithSettings(metric) && metric.type === 'top_metrics') {
-        metricAgg = {
-          metrics: [{ field: metric.field }],
-          size: metric.settings?.size ?? 1,
-        };
-        metricAgg.sort = [{ [metric.settings?.orderBy ?? '@timestamp']: metric.settings?.order ?? 'asc' }];
-      } else if (isMetricAggregationWithSettings(metric)) {
+      if (isMetricAggregationWithSettings(metric)) {
         Object.entries(metric.settings || {})
           .filter(([_, v]) => v !== null)
           .forEach(([k, v]) => {
@@ -357,32 +351,47 @@ export class ElasticQueryBuilder {
         // Elasticsearch isn't generally too picky about the data types in the request body,
         // however some fields are required to be numeric.
         // Users might have already created some of those with before, where the values were numbers.
-        if (metric.type === 'moving_avg') {
-          metricAgg = {
-            ...metricAgg,
-            ...(metricAgg?.window !== undefined && { window: this.toNumber(metricAgg.window) }),
-            ...(metricAgg?.predict !== undefined && { predict: this.toNumber(metricAgg.predict) }),
-            ...(isMovingAverageWithModelSettings(metric) && {
-              settings: {
-                ...metricAgg.settings,
-                ...Object.fromEntries(
-                  Object.entries(metricAgg.settings || {})
-                    // Only format properties that are required to be numbers
-                    .filter(([settingName]) => ['alpha', 'beta', 'gamma', 'period'].includes(settingName))
-                    // omitting undefined
-                    .filter(([_, stringValue]) => stringValue !== undefined)
-                    .map(([_, stringValue]) => [_, this.toNumber(stringValue)])
-                ),
-              },
-            }),
-          };
-        } else if (metric.type === 'serial_diff') {
-          metricAgg = {
-            ...metricAgg,
-            ...(metricAgg.lag !== undefined && {
-              lag: this.toNumber(metricAgg.lag),
-            }),
-          };
+        switch (metric.type) {
+          case 'moving_avg':
+            metricAgg = {
+              ...metricAgg,
+              ...(metricAgg?.window !== undefined && { window: this.toNumber(metricAgg.window) }),
+              ...(metricAgg?.predict !== undefined && { predict: this.toNumber(metricAgg.predict) }),
+              ...(isMovingAverageWithModelSettings(metric) && {
+                settings: {
+                  ...metricAgg.settings,
+                  ...Object.fromEntries(
+                    Object.entries(metricAgg.settings || {})
+                      // Only format properties that are required to be numbers
+                      .filter(([settingName]) => ['alpha', 'beta', 'gamma', 'period'].includes(settingName))
+                      // omitting undefined
+                      .filter(([_, stringValue]) => stringValue !== undefined)
+                      .map(([_, stringValue]) => [_, this.toNumber(stringValue)])
+                  ),
+                },
+              }),
+            };
+            break;
+
+          case 'serial_diff':
+            metricAgg = {
+              ...metricAgg,
+              ...(metricAgg.lag !== undefined && {
+                lag: this.toNumber(metricAgg.lag),
+              }),
+            };
+            break;
+
+          case 'top_metrics':
+            metricAgg = {
+              metrics: metric.settings?.metrics?.map((field) => ({ field })),
+              size: metric.settings?.size,
+            };
+
+            if (metric.settings?.orderBy) {
+              metricAgg.sort = [{ [metric.settings?.orderBy]: metric.settings?.order }];
+            }
+            break;
         }
       }
 

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -611,9 +611,8 @@ describe('ElasticResponse', () => {
           metrics: [
             {
               type: 'top_metrics',
-              settings: { order: 'top', orderBy: '@timestamp', size: 2, aggregateBy: 'sum' },
+              settings: { order: 'top', orderBy: '@timestamp', size: '2', aggregateBy: 'sum', metrics: ['@value'] },
               id: '1',
-              field: '@value',
             },
           ],
           bucketAggs: [{ type: 'date_histogram', id: '2' }],

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -440,12 +440,12 @@ describe('ElasticQueryBuilder', () => {
             {
               id: '2',
               type: 'top_metrics',
-              field: '@value',
               settings: {
                 order: 'desc',
                 orderBy: '@timestamp',
                 aggregateBy: 'sum',
-                size: 2,
+                size: '2',
+                metrics: ['@value'],
               },
             },
           ],


### PR DESCRIPTION
I basically did some refactoring to the getFields logic so we can pass in an array of types. that way we can reuse the `useFields` hook in a more versatile way. 

now useFields gets either an aggregation type or an array of basic types to filter against, that way we can use it in TopMetrics to only get dates, numbers and boolean.

I know it should also support for instance geo_point, but it requires more logic anyway.

What do you think?